### PR TITLE
feat: add ta:FifteenPuzzle

### DIFF
--- a/gem/envs/__init__.py
+++ b/gem/envs/__init__.py
@@ -139,6 +139,24 @@ register(
     only_real_words=False,
     max_turns=8,
 )
+register(
+    "ta:FifteenPuzzle-v0",
+    "gem.envs.textarena.fifteen_puzzle:FifteenPuzzleEnv",
+    num_rows=3,
+    max_turns=20,
+)
+register(
+    "ta:FifteenPuzzle-v0-easy",
+    "gem.envs.textarena.fifteen_puzzle:FifteenPuzzleEnv",
+    num_rows=2,
+    max_turns=10,
+)
+register(
+    "ta:FifteenPuzzle-v0-hard",
+    "gem.envs.textarena.fifteen_puzzle:FifteenPuzzleEnv",
+    num_rows=4,
+    max_turns=50,
+)
 
 
 # Register math dataset environments

--- a/gem/envs/textarena/fifteen_puzzle.py
+++ b/gem/envs/textarena/fifteen_puzzle.py
@@ -1,0 +1,157 @@
+"""Fifteen Puzzle environment"""
+
+import random
+import re
+from typing import Any, Dict, List, Optional, Text, Tuple, Union
+
+from gem.core import Env
+from gem.utils.constants import TERMINAL_STATE, TextArenaGameReward
+
+
+class FifteenPuzzleEnv(Env):
+    def __init__(self, max_turns: Optional[int] = 20, num_rows: Optional[int] = 2, **_):
+        super().__init__()
+        self.max_turns = max_turns
+        self.num_rows = num_rows
+        self.greatest_num = num_rows**2 - 1
+        self.reset()
+
+    def _get_instructions(self) -> str:
+        return (
+            f"You are playing the {self.greatest_num}-Puzzle game.\n"
+            f"You have to arrange the numbered tiles in ascending order from 1 to {self.greatest_num}, with the empty space located in the bottom-right corner.\n"
+            "To make a move, you can slide a tile into the empty space (represented by a double underscore, e.g. __) by using one of the following commands:\n"
+            "- 'up': Move the tile below the empty space up.\n"
+            "- 'down': Move the tile above the empty space down.\n"
+            "- 'left': Move the tile to the right of the empty space left.\n"
+            "- 'right': Move the tile to the left of the empty space right.\n"
+            "To submit your move, type the direction (e.g., 'up', 'down', 'left', or 'right') in \\boxed{...}.\n"
+            "The current board layout is shown below\n"
+            "Use logic and planning to solve the puzzle.\n"
+        )
+
+    def get_task_suffix(self) -> str:
+        return (
+            f"Here is the current board layout: \n{self._render_board()}\n"
+            "Enter your move."
+        )
+
+    def reset(self, seed: Optional[int] = None) -> Tuple[str, Dict[str, Any]]:
+        super().reset(seed)
+        self.board = self._generate_board()
+        self.turn_count = 0
+        return self._get_instructions(), {"suffix": self.get_task_suffix()}
+
+    def step(self, action: str) -> Tuple[str, float, bool, bool, Dict[str, Any]]:
+        self.turn_count += 1
+        action_search_pattern = re.compile(
+            r"\\boxed{(up|down|left|right)}"
+        )  # e.g. \\boxed{up}
+        matches = list(action_search_pattern.finditer(action))
+        clean_action = matches[-1] if matches else None
+
+        try:
+            player_guess = clean_action.group(1).lower() if clean_action else None
+        except Exception:
+            player_guess = None
+
+        if player_guess is None:
+            return (
+                TERMINAL_STATE,
+                TextArenaGameReward.format_error_reward,
+                True,
+                self.turn_count == self.max_turns,
+                {"suffix": self.get_task_suffix()},
+            )
+        else:
+            if self.turn_count >= self.max_turns:
+                # TODO: how to give a soft reward here?
+                reward = TextArenaGameReward.fail_reward
+                return (
+                    TERMINAL_STATE,
+                    reward,
+                    True,
+                    True,
+                    {"suffix": self.get_task_suffix()},
+                )
+
+            is_valid_move = self._move(player_guess)
+            if not is_valid_move:
+                next_obs = f"At turn {self.turn_count}, you chose a move {player_guess} that is outside the bounds of the board."
+                reward, terminated, truncated = (
+                    TextArenaGameReward.invalid_action_reward,
+                    False,
+                    False,
+                )
+            else:
+                if self._is_solved():
+                    next_obs = "Congratulations! You have solved the puzzle!"
+                    reward, terminated, truncated = (
+                        TextArenaGameReward.success_reward,
+                        True,
+                        False,
+                    )
+                else:
+                    next_obs = f"At turn {self.turn_count}, you made a valid move: {player_guess}.\n"
+                    reward, terminated, truncated = (
+                        TextArenaGameReward.internal_step_reward,
+                        False,
+                        False,
+                    )
+            return (
+                next_obs,
+                reward,
+                terminated,
+                truncated,
+                {"suffix": self.get_task_suffix()},
+            )
+
+    def _generate_board(self) -> List[List[Optional[int]]]:
+        tiles = list(range(1, self.greatest_num + 1)) + [None]
+        random.shuffle(tiles)
+        return [
+            tiles[i : i + self.num_rows]
+            for i in range(0, self.greatest_num + 1, self.num_rows)
+        ]
+
+    def _render_board(self) -> str:
+        rendered_board = ""
+        for row in self.board:
+            rendered_board += (
+                " ".join(["__" if x is None else f"{x:2}" for x in row]) + "\n"
+            )
+        return rendered_board
+
+    def _move(self, direction: str) -> bool:
+        empty_row, empty_col = self._get_empty_position()
+        target_row, target_col = empty_row, empty_col
+        if direction == "up" and empty_row < self.num_rows - 1:
+            target_row += 1
+        elif direction == "down" and empty_row > 0:
+            target_row -= 1
+        elif direction == "left" and empty_col < self.num_rows - 1:
+            target_col += 1
+        elif direction == "right" and empty_col > 0:
+            target_col -= 1
+        else:  # invalid move
+            return False
+
+        self.board[empty_row][empty_col], self.board[target_row][target_col] = (
+            self.board[target_row][target_col],
+            self.board[empty_row][empty_col],
+        )
+        return True
+
+    def _get_empty_position(self):
+        for r in range(self.num_rows):
+            for c in range(self.num_rows):
+                if self.board[r][c] is None:
+                    return r, c
+
+    def _is_solved(self) -> bool:
+        correct_tiles = list(range(1, self.greatest_num + 1)) + [None]
+        current_tiles = [tile for row in self.board for tile in row]
+        return current_tiles == correct_tiles
+
+    def sample_random_action(self) -> str:
+        return random.choice(["up", "down", "left", "right"])


### PR DESCRIPTION
ad fifteen_puzzle #29 

Example:

```markdown
('You are playing the 3-Puzzle game.\n'
 'You have to arrange the numbered tiles in ascending order from 1 to 3, with '
 'the empty space located in the bottom-right corner.\n'
 'To make a move, you can slide a tile into the empty space (represented by a '
 'double underscore, e.g. __) by using one of the following commands:\n'
 "- 'up': Move the tile below the empty space up.\n"
 "- 'down': Move the tile above the empty space down.\n"
 "- 'left': Move the tile to the right of the empty space left.\n"
 "- 'right': Move the tile to the left of the empty space right.\n"
 "To submit your move, type the direction (e.g., 'up', 'down', 'left', or "
 "'right') in \\boxed{...}.\n"
 'The current board layout is shown below\n'
 'Use logic and planning to solve the puzzle.\n'
 'Here is the current board layout: \n'
 ' 2  3\n'
 ' 1 __\n'
 '\n'
 'Enter your move.')
---------- action ----------
'\\boxed{down}'
---------- reward ----------
0.0
terminated:  False truncated:  False
==============================
Observation: You are playing the 3-Puzzle game.
You have to arrange the numbered tiles in ascending order from 1 to 3, with the empty space located in the bottom-right corner.
To make a move, you can slide a tile into the empty space (represented by a double underscore, e.g. __) by using one of the following commands:
- 'up': Move the tile below the empty space up.
- 'down': Move the tile above the empty space down.
- 'left': Move the tile to the right of the empty space left.
- 'right': Move the tile to the left of the empty space right.
To submit your move, type the direction (e.g., 'up', 'down', 'left', or 'right') in \boxed{...}.
The current board layout is shown below
Use logic and planning to solve the puzzle.
At turn 1, you made a valid move: down.
Here is the current board layout: 
 2 __
 1  3

Enter your move.
```