### PR TITLE
(fix): fix reset data idx.

### DIFF
--- a/gem/envs/math_env.py
+++ b/gem/envs/math_env.py
@@ -87,7 +87,7 @@ class MathEnv(Env):
         """Sample a question from the dataset."""
         super().reset(seed)
         if seed is not None:
-            self.idx = random.randint(0, len(self.dataset))
+            self.idx = random.randint(0, len(self.dataset) - 1)
         else:
             if self.idx == len(self.dataset):
                 self.epoch += 1

--- a/gem/envs/qa_env.py
+++ b/gem/envs/qa_env.py
@@ -103,7 +103,7 @@ class QaEnv(Env):
         """Sample a question from the dataset."""
         super().reset(seed)
         if seed is not None:
-            self.idx = random.randint(0, len(self.dataset))
+            self.idx = random.randint(0, len(self.dataset) - 1)
         else:
             if self.idx == len(self.dataset):
                 self.epoch += 1


### PR DESCRIPTION
`self.idx = random.randint(0, len(self.dataset) - 1)` may get idx=len(self.dataset), which will cause out of index error.

```python
    def randint(self, a, b):
        """Return random integer in range [a, b], including both end points.
        """

        return self.randrange(a, b+1)
```