### PR TITLE
feat: integrate tinker-cookbook & add spawn() for lightweight parallel environments

### DIFF
--- a/examples/train_tinker/gem_adapter.py
+++ b/examples/train_tinker/gem_adapter.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import gem
+from dataclasses import dataclass
+from copy import deepcopy
+from typing import Any, Sequence
+
+import chz
+import tinker
+from tinker_cookbook import renderers
+from tinker_cookbook.rl.types import (
+    Action,
+    Env,
+    EnvGroupBuilder,
+    Metrics,
+    Observation,
+    RLDataset,
+    RLDatasetBuilder,
+    StepResult,
+)
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.completers import StopCondition
+
+
+class GemTinkerEnv(Env):
+    def __init__(
+        self,
+        env_gem: gem.Env,
+        renderer: renderers.Renderer,
+        convo_prefix: list[renderers.Message] | None = None,
+    ):
+        self.env_gem = env_gem
+        self.renderer = renderer
+        self.convo: list[renderers.Message] = list(convo_prefix or [])
+
+    @property
+    def stop_condition(self):
+        return self.renderer.get_stop_sequences()
+
+    async def initial_observation(self) -> tuple[Observation, StopCondition]:
+        obs, _ = self.env_gem.reset()
+        self.convo.append({"role": "user", "content": obs})
+        return self.renderer.build_generation_prompt(self.convo), self.stop_condition
+
+    async def step(self, action: Action) -> StepResult:
+        message, parse_success = self.renderer.parse_response(action)
+        text = message.get("content", "") if parse_success else ""
+        next_obs, reward, terminated, truncated, info = self.env_gem.step(text)
+        reward = float(reward)
+
+        metrics: Metrics = {}
+        for k, v in (info or {}).items():
+            if isinstance(v, (int, float)):
+                metrics[k] = v
+
+        done = terminated or truncated
+        if done:
+            next_ob = tinker.ModelInput.empty()
+            next_stop = self.stop_condition
+        else:
+            self.convo.append({"role": "assistant", "content": text})
+            self.convo.append({"role": "user", "content": next_obs})
+            next_ob = self.renderer.build_generation_prompt(self.convo)
+            next_stop = self.stop_condition
+
+        return StepResult(
+            reward=reward,
+            episode_done=done,
+            next_observation=next_ob,
+            next_stop_condition=next_stop,
+            metrics=metrics,
+        )
+
+
+@dataclass(frozen=True)
+class GemEnvGroupBuilder(EnvGroupBuilder):
+    pool: list[gem.Env]
+    renderer: renderers.Renderer
+    group_size: int
+    env_id: str
+    convo_prefix: list[renderers.Message] | None = None
+    group_index: int = -1  # which env in the pool to use for this
+
+    async def make_envs(self) -> Sequence[Env]:
+        # duplicate the env for the group size
+        assert (
+            0 <= self.group_index < len(self.pool)
+        ), "group_index must be within the range of the pool size"
+        env_gem = self.pool[self.group_index]
+        return [
+            GemTinkerEnv(deepcopy(env_gem), self.renderer, self.convo_prefix)
+            for _ in range(self.group_size)
+        ]
+
+    def logging_tags(self) -> list[str]:
+        return self.env_id.split(":")
+
+
+class GemDataset(RLDataset):
+    def __init__(
+        self, builder_config: dict[str, Any], groups_per_batch: int, n_batches: int
+    ):
+        self.builder_config = builder_config
+        self.groups_per_batch = groups_per_batch
+        self.n_batches = n_batches
+
+    def get_batch(self, index: int) -> list[EnvGroupBuilder]:
+        return [
+            GemEnvGroupBuilder(group_index=i, **self.builder_config)
+            for i in range(self.groups_per_batch)
+        ]
+
+    def __len__(self) -> int:
+        return self.n_batches
+
+
+@chz.chz
+class GemDatasetBuilder(RLDatasetBuilder):
+    env_id: str
+    model_name_for_tokenizer: str
+    renderer_name: str
+    group_size: int
+    groups_per_batch: int
+    n_batches: int = 100
+    env_kwargs_json: str | None = None
+    convo_prefix: list[renderers.Message] | None = None
+    gem_path: str | None = None
+
+    async def __call__(self) -> tuple[RLDataset, RLDataset | None]:
+        env_kwargs = json.loads(self.env_kwargs_json) if self.env_kwargs_json else {}
+        pool = [
+            gem.make(self.env_id, **env_kwargs) for _ in range(self.groups_per_batch)
+        ]
+        tokenizer = get_tokenizer(self.model_name_for_tokenizer)
+        renderer = renderers.get_renderer(self.renderer_name, tokenizer=tokenizer)
+        builder_config = {
+            "pool": pool,
+            "renderer": renderer,
+            "group_size": self.group_size,
+            "env_id": self.env_id,
+            "convo_prefix": self.convo_prefix,
+        }
+        return GemDataset(builder_config, self.groups_per_batch, self.n_batches), None

--- a/examples/train_tinker/gem_adapter.py
+++ b/examples/train_tinker/gem_adapter.py
@@ -21,6 +21,8 @@ from tinker_cookbook.rl.types import (
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 from tinker_cookbook.completers import StopCondition
 
+import time
+
 
 def apply_general_prompt(init_obs: str) -> str:
     return (
@@ -164,10 +166,10 @@ class GemDatasetBuilder(RLDatasetBuilder):
 
     async def __call__(self) -> tuple[RLDataset, RLDataset | None]:
         env_kwargs = json.loads(self.env_kwargs_json) if self.env_kwargs_json else {}
-        env_parent = gem.make(self.env_id, **env_kwargs)
+        env_parent = gem.make(self.env_id, seed=int(time.time_ns()), **env_kwargs)
         seed_parent = env_parent.seed
         pool = [
-            env_parent.spawn(seed=i + seed_parent) for i in range(self.groups_per_batch)
+            env_parent.spawn(seed=i + seed_parent + 1) for i in range(self.groups_per_batch)
         ]
         tokenizer = get_tokenizer(self.model_name_for_tokenizer)
         renderer = renderers.get_renderer(self.renderer_name, tokenizer=tokenizer)

--- a/examples/train_tinker/gem_adapter.py
+++ b/examples/train_tinker/gem_adapter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import gem
 from dataclasses import dataclass
-from copy import deepcopy
 from typing import Any, Sequence
 
 import chz
@@ -78,29 +77,45 @@ class GemEnvGroupBuilder(EnvGroupBuilder):
     pool: list[gem.Env]
     renderer: renderers.Renderer
     group_size: int
-    groups_per_batch: int
+    groups_per_batch: int # TODO: may not need this
     env_id: str
     convo_prefix: list[renderers.Message] | None = None
     group_index: int = -1  # which env in the pool to use for this
 
+    # async def make_envs(self) -> Sequence[Env]:
+    #     # duplicate the env for the group size
+    #     assert (
+    #         0 <= self.group_index < len(self.pool) // self.group_size
+    #     ), "group_index must be within the range of the pool size"
+    #     assert hasattr(
+    #         self.pool[0], "get_state"
+    #     ), "env must support get_state() to run in GemEnvGroupBuilder"
+
+    #     env_0 = self.pool[self.group_index]
+    #     env_0.reset()
+    #     envs = [GemTinkerEnv(env_0, self.renderer, self.convo_prefix)]
+    #     for i in range(1, self.group_size):
+    #         env_i = self.pool[self.groups_per_batch * i + self.group_index]
+    #         env_state = deepcopy(env_0.get_state())
+    #         env_i.set_state(env_state)
+    #         envs.append(GemTinkerEnv(env_i, self.renderer, self.convo_prefix))
+    #     return envs
+
     async def make_envs(self) -> Sequence[Env]:
-        # duplicate the env for the group size
         assert (
-            0 <= self.group_index < len(self.pool) // self.group_size
-        ), "group_index must be within the range of the pool size"
+            0 <= self.group_index < len(self.pool)
+        ), "group_index should be within the range of the pool size"
         assert hasattr(
             self.pool[0], "get_state"
         ), "env must support get_state() to run in GemEnvGroupBuilder"
 
-        env_0 = self.pool[self.group_index]
-        env_0.reset()
-        envs = [GemTinkerEnv(env_0, self.renderer, self.convo_prefix)]
-        for i in range(1, self.group_size):
-            env_i = self.pool[self.groups_per_batch * i + self.group_index]
-            env_state = deepcopy(env_0.get_state())
-            env_i.set_state(env_state)
-            envs.append(GemTinkerEnv(env_i, self.renderer, self.convo_prefix))
-        return envs
+        # duplicate the env for the group size
+        env_parent = self.pool[self.group_index]
+        env_parent.reset()
+        return [
+            GemTinkerEnv(env_parent.spawn(same_state=True), self.renderer, self.convo_prefix)
+            for _ in range(self.group_size)
+        ]
 
     def logging_tags(self) -> list[str]:
         return self.env_id.split(":")
@@ -138,9 +153,9 @@ class GemDatasetBuilder(RLDatasetBuilder):
 
     async def __call__(self) -> tuple[RLDataset, RLDataset | None]:
         env_kwargs = json.loads(self.env_kwargs_json) if self.env_kwargs_json else {}
+        env_parent = gem.make(self.env_id, **env_kwargs)
         pool = [
-            gem.make(self.env_id, **env_kwargs)
-            for _ in range(self.groups_per_batch * self.group_size)
+            env_parent.spawn() for _ in range(self.groups_per_batch)
         ]
         tokenizer = get_tokenizer(self.model_name_for_tokenizer)
         renderer = renderers.get_renderer(self.renderer_name, tokenizer=tokenizer)

--- a/examples/train_tinker/run_gem_train.py
+++ b/examples/train_tinker/run_gem_train.py
@@ -20,7 +20,7 @@ class CLIConfig:
     env_kwargs_json: str | None = None  # e.g., '{"max_turns": 4}'
 
     # Training
-    prompt_type: str = 'general'
+    prompt_type: str = "general"
     group_size: int = 4
     groups_per_batch: int = 64
     n_batches: int = 200

--- a/examples/train_tinker/run_gem_train.py
+++ b/examples/train_tinker/run_gem_train.py
@@ -18,9 +18,9 @@ class CLIConfig:
     # GEM env
     env_id: str = "game:GuessTheNumber-v0"
     env_kwargs_json: str | None = None  # e.g., '{"max_turns": 4}'
-    gem_path: str | None = None
 
     # Training
+    prompt_type: str = 'general'
     group_size: int = 4
     groups_per_batch: int = 64
     n_batches: int = 200
@@ -55,18 +55,18 @@ async def cli_main(cli_config: CLIConfig):
         f"lr{cli_config.learning_rate}-g{cli_config.group_size}-b{cli_config.groups_per_batch}-"
         f"{datetime.now().strftime('%Y-%m-%d-%H-%M')}"
     )
-    log_path = cli_config.log_path or f"/tmp/tinker-examples/gem/{run_name}"
+    log_path = cli_config.log_path or f"./outputs-tinker/gem/{run_name}"
     wandb_name = cli_config.wandb_name or run_name
 
     dataset_builder = GemDatasetBuilder(
         env_id=cli_config.env_id,
         model_name_for_tokenizer=cli_config.model_name,
         renderer_name=renderer_name,
+        prompt_type=cli_config.prompt_type,
         group_size=cli_config.group_size,
         groups_per_batch=cli_config.groups_per_batch,
         n_batches=cli_config.n_batches,
         env_kwargs_json=cli_config.env_kwargs_json,
-        gem_path=cli_config.gem_path,
     )
 
     cfg = Config(

--- a/examples/train_tinker/run_gem_train.py
+++ b/examples/train_tinker/run_gem_train.py
@@ -1,0 +1,106 @@
+import asyncio
+from datetime import datetime
+
+import chz
+from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook.rl.train import AsyncConfig, Config, main
+from .gem_adapter import GemDatasetBuilder
+
+
+@chz.chz
+class CLIConfig:
+    # Model
+    model_name: str = "meta-llama/Llama-3.2-1B"
+    lora_rank: int = 32
+    renderer_name: str | None = None
+    load_checkpoint_path: str | None = None
+
+    # GEM env
+    env_id: str = "game:GuessTheNumber-v0"
+    env_kwargs_json: str | None = None  # e.g., '{"max_turns": 4}'
+    gem_path: str | None = None
+
+    # Training
+    group_size: int = 4
+    groups_per_batch: int = 64
+    n_batches: int = 200
+    learning_rate: float = 1e-5
+    max_tokens: int = 256
+    kl_penalty_coef: float = 0.0
+    num_substeps: int = 1
+
+    # Logging
+    log_path: str | None = None
+    wandb_project: str | None = None
+    wandb_name: str | None = None
+    compute_post_kl: bool = False
+    eval_every: int = 0
+    save_every: int = 25
+
+    # Service
+    base_url: str | None = None
+
+    behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "ask"
+    max_steps_off_policy: int | None = None
+
+
+async def cli_main(cli_config: CLIConfig):
+    renderer_name = (
+        cli_config.renderer_name
+        or model_info.get_recommended_renderer_name(cli_config.model_name)
+    )
+    model_name_sanitized = cli_config.model_name.replace("/", "-")
+    run_name = (
+        f"gem-{cli_config.env_id.replace(':','_')}-{model_name_sanitized}-r{cli_config.lora_rank}-"
+        f"lr{cli_config.learning_rate}-g{cli_config.group_size}-b{cli_config.groups_per_batch}-"
+        f"{datetime.now().strftime('%Y-%m-%d-%H-%M')}"
+    )
+    log_path = cli_config.log_path or f"/tmp/tinker-examples/gem/{run_name}"
+    wandb_name = cli_config.wandb_name or run_name
+
+    dataset_builder = GemDatasetBuilder(
+        env_id=cli_config.env_id,
+        model_name_for_tokenizer=cli_config.model_name,
+        renderer_name=renderer_name,
+        group_size=cli_config.group_size,
+        groups_per_batch=cli_config.groups_per_batch,
+        n_batches=cli_config.n_batches,
+        env_kwargs_json=cli_config.env_kwargs_json,
+        gem_path=cli_config.gem_path,
+    )
+
+    cfg = Config(
+        learning_rate=cli_config.learning_rate,
+        dataset_builder=dataset_builder,
+        model_name=cli_config.model_name,
+        lora_rank=cli_config.lora_rank,
+        max_tokens=cli_config.max_tokens,
+        wandb_project=cli_config.wandb_project,
+        wandb_name=wandb_name,
+        log_path=log_path,
+        base_url=cli_config.base_url,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        compute_post_kl=cli_config.compute_post_kl,
+        kl_penalty_coef=cli_config.kl_penalty_coef,
+        num_substeps=cli_config.num_substeps,
+        eval_every=cli_config.eval_every,
+        save_every=cli_config.save_every,
+        async_config=(
+            AsyncConfig(
+                max_steps_off_policy=cli_config.max_steps_off_policy,
+                groups_per_batch=cli_config.groups_per_batch,
+            )
+            if cli_config.max_steps_off_policy is not None
+            else None
+        ),
+    )
+
+    cli_utils.check_log_dir(
+        log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists
+    )
+    await main(cfg)
+
+
+if __name__ == "__main__":
+    cfg = chz.entrypoint(CLIConfig)
+    asyncio.run(cli_main(cfg))

--- a/gem/core.py
+++ b/gem/core.py
@@ -72,6 +72,18 @@ class Env(abc.ABC):
         """
         return self
 
+    def spawn(self, same_state: bool = False, **kwargs) -> "Env":
+        """Spawns a new instance of the environment with the same configuration, optionally overriding parameters.
+
+        Args:
+            same_state (bool, optional): If True, the spawned environment will have the same internal state as the current environment. Defaults to False.
+            **kwargs: Optional keyword arguments to override environment configuration.
+
+        Returns:
+            Env: The newly spawned :class:`gem.Env` instance
+        """
+        raise NotImplementedError
+
 
 class EnvWrapper(Env):
     def __init__(self, env: Env):

--- a/gem/envs/math_env.py
+++ b/gem/envs/math_env.py
@@ -86,7 +86,7 @@ class MathEnv(Env):
         except multiprocessing.context.TimeoutError:
             is_correct = False
         reward = 1.0 if is_correct else 0
-        return TERMINAL_STATE, reward, True, True, {}
+        return TERMINAL_STATE, reward, True, True, {'correct': is_correct}
 
     def _local_step(
         self, action: str

--- a/gem/envs/math_env.py
+++ b/gem/envs/math_env.py
@@ -101,7 +101,7 @@ class MathEnv(Env):
         else:
             is_correct = res
         reward = 1.0 if is_correct else 0
-        return TERMINAL_STATE, reward, True, True, {}
+        return TERMINAL_STATE, reward, True, True, {'correct': is_correct}
 
     def step(
         self, action: str
@@ -178,6 +178,7 @@ class MathEnv(Env):
                 question_key=self.question_key,
                 answer_key=self.answer_key,
                 seed=self.seed,
+                use_mp=self.use_mp,
                 **kwargs,
             )
             child.set_state(self.get_state())
@@ -186,6 +187,7 @@ class MathEnv(Env):
                 dataset=self.dataset,
                 question_key=self.question_key,
                 answer_key=self.answer_key,
+                use_mp=self.use_mp,
                 **kwargs,
             )
             if child.seed == self.seed: 

--- a/gem/envs/math_env.py
+++ b/gem/envs/math_env.py
@@ -170,6 +170,18 @@ class MathEnv(Env):
         self.first_obs = state["first_obs"]
         self.answer = state["answer"]
 
+    def spawn(self, same_state: bool=False, **kwargs) -> Env:
+        child = MathEnv(
+            dataset=self.dataset,
+            question_key=self.question_key,
+            answer_key=self.answer_key,
+            seed=self.seed,
+            **kwargs,
+        )
+        if same_state:
+            child.set_state(self.get_state())
+        return child
+
 
 if __name__ == "__main__":
     ans1 = "\\boxed{${1,2,3,4}$}"

--- a/gem/envs/math_env.py
+++ b/gem/envs/math_env.py
@@ -18,6 +18,7 @@ import functools
 import logging
 import multiprocessing
 import random
+import warnings
 from typing import Any, Optional, SupportsFloat, Tuple
 
 from datasets import Dataset, DatasetDict, load_dataset
@@ -171,15 +172,26 @@ class MathEnv(Env):
         self.answer = state["answer"]
 
     def spawn(self, same_state: bool=False, **kwargs) -> Env:
-        child = MathEnv(
-            dataset=self.dataset,
-            question_key=self.question_key,
-            answer_key=self.answer_key,
-            seed=self.seed,
-            **kwargs,
-        )
         if same_state:
+            child = MathEnv(
+                dataset=self.dataset,
+                question_key=self.question_key,
+                answer_key=self.answer_key,
+                seed=self.seed,
+                **kwargs,
+            )
             child.set_state(self.get_state())
+        else:
+            child = MathEnv(
+                dataset=self.dataset,
+                question_key=self.question_key,
+                answer_key=self.answer_key,
+                **kwargs,
+            )
+            if child.seed == self.seed: 
+                warnings.warn(
+                    "same_state is False but the seed is not changed, which may lead to the same sequence of questions."
+                )
         return child
 
 

--- a/gem/envs/mcpmark.py
+++ b/gem/envs/mcpmark.py
@@ -50,7 +50,7 @@ class MCPMarkEnv(Env):
             reward = 0.0
 
         self._cleanup()
-        return TERMINAL_STATE, reward, True, True, {}
+        return TERMINAL_STATE, reward, True, True, {'correct': bool(result.success)}
 
     def reset(self, seed: Optional[int] = None) -> Tuple[str, dict[str, Any]]:
         super().reset(seed)

--- a/gem/envs/qa_env.py
+++ b/gem/envs/qa_env.py
@@ -97,7 +97,7 @@ class QaEnv(Env):
         else:
             is_correct = self.check_correct(model_answer, self.answer)
             reward = 1.0 if is_correct else 0.0
-        return TERMINAL_STATE, reward, True, True, {}
+        return TERMINAL_STATE, reward, True, True, {'correct': bool(is_correct)}
 
     def reset(self, seed: Optional[None] = None) -> Tuple[str, dict[str, Any]]:
         """Sample a question from the dataset."""

--- a/gem/envs/reasoning_gym.py
+++ b/gem/envs/reasoning_gym.py
@@ -19,6 +19,7 @@ from typing import Any, Optional, SupportsFloat, Tuple
 
 import reasoning_gym as rg
 
+import warnings
 from gem.core import Env
 from gem.utils.constants import TERMINAL_STATE
 from gem.utils.parsing import extract_last_boxed_answer
@@ -68,3 +69,22 @@ class ReasoningGymEnv(Env):
         self.idx += 1
         self.data = data
         return question, {}
+
+    def get_state(self) -> dict[str, Any]:
+        return {"idx": self.idx, "data": self.data}
+
+    def set_state(self, state: dict[str, Any]) -> None:
+        self.idx = state["idx"]
+        self.data = state["data"]
+
+    def spawn(self, same_state: bool = False, **kwargs) -> Env:
+        if same_state:
+            child = ReasoningGymEnv(name=self.name, size=self.size, seed=self.seed)
+            child.set_state(self.get_state())
+        else:
+            child = ReasoningGymEnv(name=self.name, size=self.size, **kwargs)
+            if child.seed == self.seed:
+                warnings.warn(
+                    "same_state is False but the seed is not changed, which may lead to the same sequence of questions."
+                )
+        return child


### PR DESCRIPTION
This PR introduces two major updates:
1. tinker-cookbook integration: Adds an example showcasing RL training with tinker-cookbook, utilizing tinker's api to train agents using GEM on laptops
2. `Env.spawn()` method: Adds a new spawn() function to the Env class, enabling lightweight creation of parallel. Useful for cases where shared resources (e.g., HF datasets) should only be loaded once.