### PR TITLE
Fix game:FifteenPuzzle

### DIFF
--- a/gem/envs/game_env/fifteen_puzzle.py
+++ b/gem/envs/game_env/fifteen_puzzle.py
@@ -55,7 +55,6 @@ class FifteenPuzzleEnv(Env):
         if self._is_random:
             candidates = [(2, 10), (3, 20), (4, 50)]
             self.num_rows, self.max_turns = random.choice(candidates)
-            self.greatest_num = self.num_rows**2 - 1
 
         self.greatest_num = self.num_rows**2 - 1
         self.board = self._generate_board()

--- a/gem/envs/game_env/fifteen_puzzle.py
+++ b/gem/envs/game_env/fifteen_puzzle.py
@@ -27,7 +27,6 @@ class FifteenPuzzleEnv(Env):
         super().__init__()
         self.max_turns = max_turns
         self.num_rows = num_rows
-        self.greatest_num = num_rows**2 - 1
         self._is_random = num_rows is None or max_turns is None
         self.reset()
 
@@ -58,6 +57,7 @@ class FifteenPuzzleEnv(Env):
             self.num_rows, self.max_turns = random.choice(candidates)
             self.greatest_num = self.num_rows**2 - 1
 
+        self.greatest_num = self.num_rows**2 - 1
         self.board = self._generate_board()
         self.turn_count = 0
         return self._get_instructions(), {"suffix": self.get_task_suffix()}


### PR DESCRIPTION
Fix `game:FifteenPuzzle-v0-random` env creation.

Since the constructor inputs for this env are `None`, `self.greatest_num` can only be set inside `.reset()` (and not inside `__init__()`).